### PR TITLE
Some enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,20 @@ Just a text template, you can customize it, e.g., "%d D / %h H / %m M / %s S" or
 
 Set it to `true` to pad numbers with a leading 0, e.g., "10 H / 9 M / 5 S" becomes "10 H / 09 M / 05 S"
 
+#### sync
+
+* type: boolean
+* default: false
+
+Ensure we start synced with the computer time. Usefull if you want to use in conjonction with a clock display
+
+#### resync
+
+* type: int
+* default: 0
+
+Period (in minutes) to resync the countdown with the computer time. Without setting it, a long countdown time will drift from the real time.
+
 
 ## Methods
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ The target date, allow date object, time number (milliseconds) and valid date st
 * type: boolean
 * default: false
 
-Set it `true` to update the date number per one tenth second.
+Set it to `true` to update the date number per one tenth second.
 
 
 #### end
@@ -99,10 +99,17 @@ The function will be run when the countdown end.
 #### text
 
 * type: string
-* default: "%s days, %s hours, %s minutes, %s seconds"
+* default: "%d days, %h hours, %m minutes, %s seconds"
 
-Just a text template, you can customize it, e.g., "%s D / %s H / %s M / %s S".
+Just a text template, you can customize it, e.g., "%d D / %h H / %m M / %s S" or "%m min / %s sec" .
 
+
+#### pad
+
+* type: boolean
+* default: false
+
+Set it to `true` to pad numbers with a leading 0, e.g., "10 H / 9 M / 5 S" becomes "10 H / 09 M / 05 S"
 
 
 ## Methods

--- a/src/countdown.js
+++ b/src/countdown.js
@@ -211,10 +211,19 @@
 
         template: function () {
             return this.defaults.text
-                    .replace("%s", this.days)
-                    .replace("%s", this.hours)
-                    .replace("%s", this.minutes)
-                    .replace("%s", this.getSecondsText());
+                    .replace("%d", this.padNumber(this.days))
+                    .replace("%h", this.padNumber(this.hours))
+                    .replace("%m", this.padNumber(this.minutes))
+                    .replace("%s", this.padNumber(this.getSecondsText()));
+        },
+
+        padNumber: function (n){
+        	if(this.defaults.pad){
+	        	return (n < 10) ? '0' + n : n;
+        	}
+        	else{
+        		return n;
+        	}
         },
 
         getSecondsText: function () {
@@ -228,7 +237,9 @@
         date: null,
         fast: false,
         end: $.noop,
-        text: "%s days, %s hours, %s minutes, %s seconds"
+        text: "%d days, %h hours, %m minutes, %s seconds",
+        pad: false
+
     };
 
     // Set default settings

--- a/src/countdown.js
+++ b/src/countdown.js
@@ -98,16 +98,44 @@
             if (!this.active && this.ready()) {
                 this.active = true;
                 this.reset();
+                if(this.defaults.sync){
+					/* ensure we start right on a second synced with the computer time */
+	                this.syncToSecond();
+                }
+                if(this.defaults.resync >0){
+					/* periodically resync with computer time */
+		            this.autoResync=setInterval($.proxy(this.resync, this), 1000 * this.defaults.resync);
+                }
                 this.autoUpdate = this.defaults.fast ?
                     setInterval($.proxy(this.fastUpdate, this), 100) :
                     setInterval($.proxy(this.update, this), 1000);
             }
         },
+		
+		syncToSecond: function () {
+			var wait= 1000 - ((new Date().getTime()) % 1000);
+			var start = new Date().getTime();
+			for (var i = 0; i < 1e7; i++) {
+				if ((new Date().getTime() - start) > wait){
+					break;
+				}
+			}
+		},
+		
+		resync: function () {
+			/* console.log('resyncing'); */
+			this.stop();
+			this.start();
+		},
+
 
         stop: function () {
             if (this.active) {
                 this.active = false;
                 clearInterval(this.autoUpdate);
+				if(this.defaults.resync >0){
+					clearInterval(this.autoResync);
+				}
             }
         },
 
@@ -238,6 +266,8 @@
         fast: false,
         end: $.noop,
         text: "%d days, %h hours, %m minutes, %s seconds",
+        sync: false,
+        resync: 0,
         pad: false
 
     };


### PR DESCRIPTION
Here are some enhancements

1) Change text formatting to allow displaying texts without days or hours.

2) Option to pad numbers.

3) Option to start *synced* with the exact second of the computer time (not between 2 seconds). Very usefull if using countdown in conjonction with a clock display. Ensure both will display in sync.

4) Option to resync the countdown periodically with the computer time. Without it, because the countdown is triggered by a 1000ms timeout, it fastly drift from the real time depending on computer/browser cpu usage. I've set it to default to 0 (inactive), but you should certainly default it to at least 60min (or less) , to ensure accurate timing by default.

HTH